### PR TITLE
Update to handle include-folder 0.9.0 and test preserveFilenames.

### DIFF
--- a/lib/folderify.js
+++ b/lib/folderify.js
@@ -95,8 +95,18 @@ function folderify(file) {
         }
     }
 
-    function buildOriginalSource(folder, filter) {
-        var fnBody = includeFolder._testHook.buildSource(folder, filter);
+    function buildOriginalSource(folder, filter, options) {
+
+        if (!filter) {
+            filter = /^[^.].*$/;
+        }
+
+        if (typeof options !== 'object') {
+            options = {};
+        }
+
+        var fnBody = includeFolder.buildSource(folder, filter, options);
+
         return "(function(){" +
             fnBody +
             "})()";
@@ -125,10 +135,16 @@ function folderify(file) {
                 }
 
 
+                var options;
+
+                if (node.arguments.length > 2) {
+                    options = eval('('+node.arguments[2].source()+')');
+                }
+
 
                 var originalSource;
                 //console.log(folder)
-                originalSource = buildOriginalSource(folder, filesFilter);
+                originalSource = buildOriginalSource(folder, filesFilter, options);
                 //console.dir(originalSource)
                 var brfsStream = brfs(folder + "bogus.txt");
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "lodash": "~2.4.1",
     "brfs": "0.0.8",
-    "include-folder": "~0.7.0",
+    "include-folder": "~0.9.0",
     "through": "~2.3.4",
     "falafel": "~0.3.1",
     "concat-stream": "~1.2.1"

--- a/test/folderify_test.js
+++ b/test/folderify_test.js
@@ -57,10 +57,10 @@ describe("folderify", function() {
 
 
         var expected = 'var iF = undefined;\n' +
-            "var files = (function(){var self={},fs = require('fs');\n" +
-            'self.file3OtherFile = "this is file3OtherContent content";\n' +
-            'self.file1 = "this is file1 content";\n' +
-            'self.file1_1 = "this is file1_1 content";\n' +
+            'var files = (function(){var self={},fs = require("fs");\n' +
+            'self["file3OtherFile"] = "this is file3OtherContent content";\n' +
+            'self["file1"] = "this is file1 content";\n' +
+            'self["file1_1"] = "this is file1_1 content";\n' +
             'return self})()\n';
 
         checkTransform(source, expected, done);
@@ -73,11 +73,27 @@ describe("folderify", function() {
 
 
         var expected = 'var iF = undefined;\n' +
-            "var files = (function(){var self={},fs = require('fs');\n" +
-            'self.DS_STORE = "ciao";\n' +
-            'self.file3OtherFile = "this is file3OtherContent content";\n' +
-            'self.file1 = "this is file1 content";\n' +
-            'self.file1_1 = "this is file1_1 content";\n' +
+            'var files = (function(){var self={},fs = require("fs");\n' +
+            'self["DS_STORE"] = "ciao";\n' +
+            'self["file3OtherFile"] = "this is file3OtherContent content";\n' +
+            'self["file1"] = "this is file1 content";\n' +
+            'self["file1_1"] = "this is file1_1 content";\n' +
+            'return self})()\n';
+
+        checkTransform(source, expected, done);
+    });
+
+    it('preserve filenames', function(done) {
+        var source =
+            'var iF = require("include-folder");\n' +
+            'var files = iF("./test/files",null,{preserveFilenames:true})\n';
+
+
+        var expected = 'var iF = undefined;\n' +
+            'var files = (function(){var self={},fs = require("fs");\n' +
+            'self["file-3-other&file.txt"] = "this is file3OtherContent content";\n' +
+            'self["file1.check"] = "this is file1 content";\n' +
+            'self["file1.txt"] = "this is file1_1 content";\n' +
             'return self})()\n';
 
         checkTransform(source, expected, done);


### PR DESCRIPTION
Currently, if you use the `preserveFilenames = true` option with `include-folder`, then you can't use `folderify`. This pullreq updates `folderify` to `0.9.0`, accounts for some behavior changes in the `buildSource` function since `0.7.0`, and passes through the `options` argument so that `preserveFilenames` works.